### PR TITLE
Added intelligent mode

### DIFF
--- a/silencer.py
+++ b/silencer.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 from pynput import keyboard
+import datetime
 import os
 import signal
 import gi
@@ -24,15 +25,32 @@ class GtkThread(Thread):
 
 
 class Silencer:
+
+    MODE_PUSH_TO_TALK = 1
+    MODE_TOGGLE_TO_TALK = 2
+    MODE_INTELLIGENT_DETECT = 3
+    
     def __init__(self, config):
-        # Mic key bind init
+        
+        # Configuration reading
         self.config = config
         self.mic_key = config['keybind']
         self.mic_sound_card = config['sound_card_id']
+        if (config['hold_to_talk'] == True or config['hold_to_talk'] == self.MODE_PUSH_TO_TALK):
+            self.mode = self.MODE_PUSH_TO_TALK
+        elif (config['hold_to_talk'] == False or config['hold_to_talk'] == self.MODE_TOGGLE_TO_TALK):
+            self.mode = self.MODE_TOGGLE_TO_TALK
+        else:
+            self.mode = self.MODE_INTELLIGENT_DETECT
+
+        # State setup
         self.mic_muted = True
-        self.mic_hold_to_talk = config['hold_to_talk']
-        self.mic_keybind_setup_dialog = None
+        self.start_press = None
+        self.switching_mode = False
+
+        # GTK init
         self.mic_keybind_setup_active = False
+        self.mic_keybind_setup_dialog = None
         self.mic_keybind_setup_key = None
         self.mic_keybind_setup_dialog_key_label = None
 
@@ -66,11 +84,31 @@ class Silencer:
         about_item = Gtk.MenuItem('Silencer v0.3.3  💀')
         menu.append(about_item)
 
+        # Separator
+        menu.append(Gtk.SeparatorMenuItem())
+
+        # Toggle mode toggle
+        self.tmt_toggle_item = Gtk.RadioMenuItem(group=None, label='Push to toggle')
+        self.tmt_toggle_item.set_active(self.mode == self.MODE_TOGGLE_TO_TALK)
+        menu.append(self.tmt_toggle_item)
+
         # Hold to talk toggle
-        ppt_toggle_item = Gtk.CheckMenuItem('Hold to talk')
-        ppt_toggle_item.set_active(self.mic_hold_to_talk)
-        ppt_toggle_item.connect('toggled', self.hold_to_talk_mode_toggled)
-        menu.append(ppt_toggle_item)
+        self.ppt_toggle_item = Gtk.RadioMenuItem(group=self.tmt_toggle_item, label='Hold to talk')
+        self.ppt_toggle_item.set_active(self.mode == self.MODE_PUSH_TO_TALK)
+        menu.append(self.ppt_toggle_item)
+
+        # Intelligent mode toggle
+        self.intelligent_toggle_item = Gtk.RadioMenuItem(group=self.tmt_toggle_item, label='Intelligent mode')
+        self.intelligent_toggle_item.set_active(self.mode == self.MODE_INTELLIGENT_DETECT)
+        menu.append(self.intelligent_toggle_item)
+
+        # Bind the connectors
+        self.tmt_toggle_item.connect('activate', self.toggle_to_talk_mode_toggled)
+        self.ppt_toggle_item.connect('activate', self.hold_to_talk_mode_toggled)
+        self.intelligent_toggle_item.connect('activate', self.intelligent_mode_toggled)
+
+        # Separator
+        menu.append(Gtk.SeparatorMenuItem())
 
         # Keybind setup item
         keybind_setup_item = Gtk.MenuItem('Keybind setup')
@@ -97,6 +135,7 @@ class Silencer:
 
     # Start all processes using threads
     def start_processes(self):
+
         # To be able to exit with ^C
         signal.signal(signal.SIGINT, self.stop_processes)
 
@@ -129,11 +168,16 @@ class Silencer:
         if self.mic_keybind_setup_active:
             self.mic_keybind_setup_key = str(key)
             self.mic_keybind_setup_dialog_key_label.set_label(self.mic_keybind_setup_key)
+        
+        elif self.mode == self.MODE_INTELLIGENT_DETECT and self.mic_key in str(key):
+            if self.start_press == None:
+                self.start_press = datetime.datetime.now()
+            self.unmute_mic()
 
         elif self.mic_key in str(key):
-            if self.mic_hold_to_talk is True:
+            if self.mode == self.MODE_PUSH_TO_TALK:
                 self.unmute_mic()
-            elif self.mic_hold_to_talk is False:
+            else:
                 if self.mic_muted is True:
                     self.unmute_mic()
                 elif self.mic_muted is False:
@@ -141,7 +185,14 @@ class Silencer:
 
     # When a keyboard key is released
     def on_release(self, key):
-        if self.mic_key in str(key) and self.mic_hold_to_talk is True:
+        if self.mic_key in str(key) and self.mode == self.MODE_INTELLIGENT_DETECT:
+            end_press = datetime.datetime.now()
+            diff_press = end_press - self.start_press
+            if (diff_press > datetime.timedelta(milliseconds=250)):
+                self.mute_mic()
+                self.start_press = None
+
+        elif self.mic_key in str(key) and self.mode == self.MODE_PUSH_TO_TALK:
             self.mute_mic()
 
     # Mute the microphone
@@ -162,9 +213,34 @@ class Silencer:
     def set_mic_capture(self, on):
         os.system('amixer -c {0} set Mic {1}'.format(self.mic_sound_card, 'cap' if on is True else 'nocap'))
 
-    # Toggle hold to talk mode
+    def toggle_to_talk_mode_toggled(self, *source):
+        if self.switching_mode is True:
+            return
+        self.switching_mode = True
+        self.mode = self.MODE_TOGGLE_TO_TALK
+        self.reset_toggles()
+        self.switching_mode = False
+
     def hold_to_talk_mode_toggled(self, *source):
-        self.mic_hold_to_talk = not self.mic_hold_to_talk
+        if self.switching_mode is True:
+            return
+        self.switching_mode = True
+        self.mode = self.MODE_PUSH_TO_TALK
+        self.reset_toggles()
+        self.switching_mode = False
+
+    def intelligent_mode_toggled(self, *source):
+        if self.switching_mode is True:
+            return
+        self.switching_mode = True
+        self.mode = self.MODE_INTELLIGENT_DETECT
+        self.reset_toggles()
+        self.switching_mode = False
+
+    def reset_toggles(self):
+        self.tmt_toggle_item.set_active(self.mode == self.MODE_TOGGLE_TO_TALK)
+        self.ppt_toggle_item.set_active(self.mode == self.MODE_PUSH_TO_TALK)
+        self.intelligent_toggle_item.set_active(self.mode == self.MODE_INTELLIGENT_DETECT)
 
     # Open keybind setup dialog
     def open_set_up_keybind_dialog(self, *source):
@@ -182,7 +258,7 @@ class Silencer:
 
     # Save config to json file
     def save_config(self):
-        self.config['hold_to_talk'] = self.mic_hold_to_talk
+        self.config['hold_to_talk'] = self.mode
         self.config['keybind'] = self.mic_key
 
         json.dump(self.config, open('silencer-config.json', 'w'), indent=2)


### PR DESCRIPTION
Menu is now a radio menu item set. Sets a mode property...

All old modes still work as before, new mode works like this:
- Hold to talk: press to unmute and release 250ms later or more to mute automatic
- Pust to talk: press & release within 250ms and it will toggle the mic

Makes pushing to talk super easy and prevents flickering if someone alternates between the two old modes.